### PR TITLE
Issue/76

### DIFF
--- a/mpet/plot/plot_data.py
+++ b/mpet/plot/plot_data.py
@@ -641,14 +641,7 @@ def show_data(indir, plot_type, print_flag, save_flag, data_only, vOut=None, pOu
                             lines3[pInd,vInd].set_ydata(datay3)
                             lines_local = np.vstack((lines_local, lines3))
                     else:
-                        # double check size of datay, since nosqueeze is not enough
-                        datay = utils.get_dict_key(data, cstr[pInd,vInd])
-                        if len(datay.shape) > 1:
-                            # if actually 2d array
-                            datay = utils.get_dict_key(data, cstr[pInd,vInd],
-                                                       squeeze=False)[:,tind]
-                        else:  # 1D array
-                            datay = utils.get_dict_key(data, cstr[pInd,vInd])[tind]
+                        datay = utils.get_dict_key(data, cstr[pInd,vInd])[tind]
                         lines[pInd,vInd].set_ydata(datay)
                         lines_local = lines.copy()
                     toblit.extend(lines_local.reshape(-1))


### PR DESCRIPTION
A fix for crashing csld_c and csld_a plots. The array dimension check didn't seem necessary, so I removed it. Maybe this was left over from input format refactoring?