### PR TITLE
Issue/79

### DIFF
--- a/mpet/main.py
+++ b/mpet/main.py
@@ -82,7 +82,7 @@ def run_simulation(config, outdir):
     except Exception as e:
         print(str(e))
         simulation.ReportData(simulation.CurrentTime)
-        raise
+        pass
     except KeyboardInterrupt:
         print("\nphi_applied at ctrl-C:",
               simulation.m.phi_applied.GetValue(), "\n")


### PR DESCRIPTION
This PR makes two changes related to file output:
- sim_data is deleted before copying output to prevent multiple ouptput_data files from existing in sim_data
- If mpet crashes, output data is still moved/copied to sim_output