### PR TITLE
use conda daetools package instead of docker image

### DIFF
--- a/.github/workflows/mpet-docker-regression-test.yml
+++ b/.github/workflows/mpet-docker-regression-test.yml
@@ -6,14 +6,13 @@ jobs:
   test:
     
     runs-on: ubuntu-latest
-    container:
-      image: vikko00/daetools:1.9.0
-
+    strategy:
+      matrix:
+        python-version: ["3.7","3.8","3.9"]
+    defaults:
+      run:
+        shell: bash -l {0}
     steps:
-    - name: update container
-      run: |
-        apt-get update
-        apt-get upgrade -y
 
     - uses: actions/checkout@v1
       with:
@@ -27,6 +26,17 @@ jobs:
         fetch-depth: 1
         path: base-mpet
         ref: ${{ github.base_ref }}
+
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        auto-update-conda: true
+        python-version: ${{ matrix.python-version }}
+        activate-environment: mpet-env
+
+    - name: Install daetools via conda
+      run: |
+        conda activate mpet-env
+        conda install -c https://conda.lipsum.eu -c conda-forge daetools python=${{ matrix.python-version }} pip
 
     - name: Install additional dependencies using mpet's setup.py
       run: |
@@ -46,6 +56,7 @@ jobs:
 
     - name: run tests for modified branch and get coverage
       run: |
+        conda activate mpet-env
         cd mpet/bin/workdir
         coverage run --source=../../mpet/ run_tests.py --test_dir ./tests --output_dir ../../bin/workdir/modified > /dev/null
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
     packages=['mpet','mpet.plot','mpet.electrode','mpet.config'],
     install_requires=['numpy','scipy','matplotlib','pyQt5', 'h5py', 'configparser', 'schema'],
     extras_require={'test':['pytest','coverage', 'coveralls', 'flake8']},
-    python_requires='>=3.5,<3.8',
+    python_requires='>=3.5',
     scripts=['bin/mpetrun.py','bin/mpetplot.py'],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
This pull request uses daetools from a conda repository and updates the python requirements of mpet

TODO: put daetools in conda forge instead of my private server