### PR TITLE
Test all python versions

### DIFF
--- a/.github/workflows/mpet-regression-test.yml
+++ b/.github/workflows/mpet-regression-test.yml
@@ -7,6 +7,7 @@ jobs:
     
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.7","3.8","3.9"]
     defaults:


### PR DESCRIPTION
This PR makes the CI always run all python versions, instead of cancelling steps if one version fails. This fixes issue #91.

I've also renamed the CI file, as we're no longer using docker.