### PR TITLE
Updates to Github actions

### DIFF
--- a/.github/workflows/mpet-code-style.yml
+++ b/.github/workflows/mpet-code-style.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Set up python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
           architecture: x64

--- a/.github/workflows/mpet-code-style.yml
+++ b/.github/workflows/mpet-code-style.yml
@@ -9,13 +9,13 @@ jobs:
 
     steps:
       - name: Set up python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: 3.9
           architecture: x64
       
       - name: Checkout MPET
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 1
           path: mpet

--- a/.github/workflows/mpet-regression-test.yml
+++ b/.github/workflows/mpet-regression-test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7","3.8","3.9","3.10"]
+        python-version: ["3.8","3.9","3.10","3.11"]
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/mpet-regression-test.yml
+++ b/.github/workflows/mpet-regression-test.yml
@@ -15,18 +15,10 @@ jobs:
         shell: bash -l {0}
     steps:
 
-    - uses: actions/checkout@v1
-      with:
-        fetch-depth: 1
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 1
         path: mpet
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 1
-        path: base-mpet
-        ref: ${{ github.base_ref }}
 
     - uses: conda-incubator/setup-miniconda@v2
       with:


### PR DESCRIPTION
v2 actions need to be updated to v3:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/